### PR TITLE
Wifi測定結果画面に施設名を追加しました #49

### DIFF
--- a/lib/features/measurement_wifi/presentation/wifi_result.dart
+++ b/lib/features/measurement_wifi/presentation/wifi_result.dart
@@ -20,7 +20,6 @@ class WiFiResultDialog extends StatelessWidget {
             width: size.width * 0.8,
             height: size.height * 0.6,
             decoration: BoxDecoration(
-              // ボタンのスタイルに合わせて角を切ってもいいかも
               borderRadius: BorderRadius.circular(16),
               image: const DecorationImage(
                 image: AssetImage('assets/images/map.png'),
@@ -30,7 +29,6 @@ class WiFiResultDialog extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.only(bottom: 16),
               child: ElevatedButton.icon(
-                // もっといいアイコンありそう
                 icon: const Icon(Icons.share),
                 onPressed: () {},
                 label: const Text('結果をシェア'),
@@ -50,11 +48,21 @@ class WiFiResultDialog extends StatelessWidget {
             alignment: Alignment.center,
             children: [
               Image.asset('assets/images/balloon.png'),
-              Column(
-                children: [
-                  Material(
-                    color: Colors.transparent,
-                    child: Row(
+              Material(
+                color: Colors.transparent,
+                child: Column(
+                  children: [
+                    const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 40),
+                      child: Text(
+                        '東京スカイツリー東京スカイツリー東京スカイツリー東京スカイツリー',
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(fontSize: 12,),
+                      ),
+                    ),
+                    const SizedBox(height: 8,),
+                    Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
@@ -63,6 +71,7 @@ class WiFiResultDialog extends StatelessWidget {
                           style: const TextStyle(
                             fontSize: 48,
                             fontWeight: FontWeight.bold,
+                            height: 1,
                           ),
                         ),
                         const SizedBox(
@@ -70,28 +79,29 @@ class WiFiResultDialog extends StatelessWidget {
                         ),
                         const Text(
                           'Mbps',
-                          style: TextStyle(fontSize: 16, height: 4),
+                          style: TextStyle(fontSize: 16, height: 3),
                         )
                       ],
                     ),
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: List.generate(3, (index) {
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 2),
-                        child: Image.asset(
-                          'assets/images/star.png',
-                          width: 32,
-                        ),
-                      );
-                    }),
-                  )
-                ],
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: List.generate(3, (index) {
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 2),
+                          child: Image.asset(
+                            'assets/images/star.png',
+                            width: 32,
+                          ),
+                        );
+                      }),
+                    )
+                  ],
+                ),
               ),
             ],
           ),
         ),
+        // ピン
         Align(
           child: SvgPicture.asset(
             'assets/images/push-pin02.svg',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -568,7 +568,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -776,7 +776,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   speed_test_dart:
     dependency: "direct main"
     description:
@@ -839,7 +839,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.14"
   timing:
     dependency: transitive
     description:
@@ -867,7 +867,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
<img width="264" alt="スクリーンショット 2023-01-19 0 44 15" src="https://user-images.githubusercontent.com/45866095/213217869-910e70ec-37d4-4934-8fd4-426ff4dc3ded.png">

- 吹き出しの中に配置しました。
- 2行のみ、はみ出しは分は ... に置き換えました。